### PR TITLE
Feat/feeds

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,6 +13,7 @@ target 'Where_Are_You' do
 	pod 'Moya'
 	pod 'KakaoSDK'
 	pod 'KakaoMapsSDK'
+	pod 'Kingfisher', '~> 7.0'
 
 
 	target 'Where_Are_You_Tests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,6 +41,7 @@ PODS:
   - KakaoSDKUser (2.22.6):
     - KakaoSDKAuth (= 2.22.6)
   - KeychainAccess (4.2.2)
+  - Kingfisher (7.12.0)
   - Moya (15.0.0):
     - Moya/Core (= 15.0.0)
   - Moya/Core (15.0.0):
@@ -53,6 +54,7 @@ DEPENDENCIES:
   - KakaoMapsSDK
   - KakaoSDK
   - KeychainAccess
+  - Kingfisher (~> 7.0)
   - Moya
   - SnapKit
   - SwiftLint
@@ -74,6 +76,7 @@ SPEC REPOS:
     - KakaoSDKTemplate
     - KakaoSDKUser
     - KeychainAccess
+    - Kingfisher
     - Moya
     - SnapKit
     - SwiftLint
@@ -94,10 +97,11 @@ SPEC CHECKSUMS:
   KakaoSDKTemplate: 341018b73086f2044757d38afd40b41d1c4dedd1
   KakaoSDKUser: 1adf80a8b5ca3f144c4d55fb8eb207f59d1c6b0c
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
+  Kingfisher: 53a10ea35051a436b5fb626ca2dd8f3144d755e9
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   SnapKit: d612e99e678a2d3b95bf60b0705ed0a35c03484a
   SwiftLint: eb47480d47c982481592c195c221d11013a679cc
 
-PODFILE CHECKSUM: 012157ff149bb70379388c0f5f8213c109653792
+PODFILE CHECKSUM: fcd78b3f1ee6e6e15e65a2a11a4836b107490e13
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Where_Are_You.xcodeproj/project.pbxproj
+++ b/Where_Are_You.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -567,7 +567,11 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		99BC80742CEEC6420040E44B /* CoreData */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = CoreData; sourceTree = "<group>"; };
+		99BC80742CEEC6420040E44B /* CoreData */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = CoreData;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1678,7 +1682,6 @@
 				};
 			};
 			buildConfigurationList = 995358342C00C555005BF799 /* Build configuration list for PBXProject "Where_Are_You" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1689,6 +1692,7 @@
 			mainGroup = 995358302C00C555005BF799;
 			packageReferences = (
 			);
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 9953583A2C00C555005BF799 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -2266,11 +2270,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Where_Are_You/Resources/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 접근 권한";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앨범 접근 권한";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진을 선택하고 업로드하기 위해 사진 라이브러리 접근이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2302,11 +2305,10 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Where_Are_You/Resources/Info.plist";
 				INFOPLIST_KEY_NSCameraUsageDescription = "카메라 접근 권한";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "내 위치 확인을 위해 권한이 필요합니다.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "앨범 접근 권한";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "사진을 선택하고 업로드하기 위해 사진 라이브러리 접근이 필요합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/ViewControllers/FeedsViewController.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/ViewControllers/FeedsViewController.swift
@@ -13,21 +13,14 @@ class FeedsViewController: UIViewController {
     private var feedsView = FeedsView()
     private var noFeedsView = NoDataView()
     var viewModel: FeedViewModel!
-//    private var feedImagesViewController: FeedImagesViewController!
     
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        print("FeedsViewController - viewDidLoad() called") // 확인 로그
-        print("Is viewModel nil? \(viewModel == nil)") // viewModel nil 여부 확인
-        
         setupViewModel()
-        print("Is viewModel nil after setupViewModel? \(viewModel == nil)") // viewModel 초기화 여부 확인
-        
         setupViews()
         setupTableView()
         setupBindings()
-//        addFeedImagesViewController()
         viewModel.fetchFeeds()
     }
     
@@ -59,17 +52,6 @@ class FeedsViewController: UIViewController {
         feedsView.feedsTableView.delegate = self
         feedsView.feedsTableView.dataSource = self
         feedsView.feedsTableView.register(FeedsTableViewCell.self, forCellReuseIdentifier: FeedsTableViewCell.identifier)
-    }
-
-    private func addFeedImagesViewController() {
-//        feedImagesViewController = FeedImagesViewController()
-//        addChild(feedImagesViewController)
-//        feedsView.addSubview(feedImagesViewController.view)
-//        feedImagesViewController.didMove(toParent: self)
-//        
-//        feedImagesViewController.view.snp.makeConstraints { make in
-//            make.edges.equalToSuperview()
-//        }
     }
 }
 

--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/FeedDetailBoxView.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/FeedDetailBoxView.swift
@@ -105,7 +105,7 @@ class FeedDetailBoxView: UIView {
         
         profileStack.snp.makeConstraints { make in
             make.leading.equalToSuperview().inset(LayoutAdapter.shared.scale(value: 10))
-            make.top.bottom.equalToSuperview().inset(LayoutAdapter.shared.scale(value: 10))
+            make.centerY.equalToSuperview()
         }
         
         profileImage.snp.makeConstraints { make in

--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/FeedsTableViewCell.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/FeedsTableViewCell.swift
@@ -93,7 +93,7 @@ class FeedsTableViewCell: UITableViewCell {
         }
         
         detailBox.profileImage.setImage(from: feed.profileImage, placeholder: UIImage(named: "basic_profile_image"))
-        detailBox.dateLabel.text = feed.startTime
+        detailBox.dateLabel.text = feed.startTime.formattedDate(to: .yearMonthDate)
         detailBox.locationLabel.text = feed.location
         detailBox.titleLabel.text = feed.title
         self.imageUrls = feed.feedImageInfos.map { $0.feedImageURL }

--- a/Where_Are_You/Resources/Info.plist
+++ b/Where_Are_You/Resources/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>사진을 선택하고 업로드하기 위해 사진 라이브러리 접근이 필요합니다.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Where_Are_You/Utils/Extensions.swift
+++ b/Where_Are_You/Utils/Extensions.swift
@@ -147,11 +147,26 @@ extension UIImageView {
     }
 }
 
+extension DateFormatter {
+    static func formatter(for format: DateFormat) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = format.rawValue
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter
+    }
+}
+
+enum DateFormat: String {
+    case server = "yyyy-MM-dd'T'HH:mm:ss.SSS" // 서버의 날짜 형식
+    case yearMonthDate = "yy.MM.dd"                // "YY.MM.dd" 형태
+    case yearMonth = "yyyy.MM"               // "YYYY.MM" 형태
+}
+
 extension String {
-    func toImage() -> UIImage? {
-        if let data = Data(base64Encoded: self, options: .ignoreUnknownCharacters){
-            return UIImage(data: data)
+    func formattedDate(to format: DateFormat) -> String {
+        guard let date = DateFormatter.formatter(for: .server).date(from: self) else {
+            return self // 변환 실패 시 원래 문자열 반환
         }
-        return nil
+        return DateFormatter.formatter(for: format).string(from: date)
     }
 }


### PR DESCRIPTION
refactor: 데이터 충돌 ( 누락된 User 엔티티 추가), url String 값 이미지로 수정.

feat: extension 추가 (DateFormat)

```
extension DateFormatter {
    static func formatter(for format: DateFormat) -> DateFormatter {
        let formatter = DateFormatter()
        formatter.dateFormat = format.rawValue
        formatter.locale = Locale(identifier: "ko_KR")
        return formatter
    }
}

enum DateFormat: String {
    case server = "yyyy-MM-dd'T'HH:mm:ss.SSS" // 서버의 날짜 형식
    case yearMonthDate = "yy.MM.dd"                // "YY.MM.dd" 형태
    case yearMonth = "yyyy.MM"               // "YYYY.MM" 형태
}

extension String {
    func formattedDate(to format: DateFormat) -> String {
        guard let date = DateFormatter.formatter(for: .server).date(from: self) else {
            return self // 변환 실패 시 원래 문자열 반환
        }
        return DateFormatter.formatter(for: format).string(from: date)
    }
}
```
사용방법
```
let formattedDate = serverDateString.formattedDate(to: .display)
print(formattedDate) // 출력: "24.11.04"

// "[[YYYY.MM](http://yyyy.mm/)](http://yyyy.mm/)" 형식으로 변환
let yearMonthDate = serverDateString.formattedDate(to: .yearMonth)
print(yearMonthDate) // 출력: "2024.11"
```

feat(#57): KingFisher 라이브러리 추가

URL String 값을 이미지로 바꾸는 라이브러리