### PR TITLE
feat(#35): postTokenReissue API 구현 feat(#35): deleteMemberAPI 성공시 모든 UserDefaults데이터 삭제 추가

### DIFF
--- a/Where_Are_You.xcodeproj/project.pbxproj
+++ b/Where_Are_You.xcodeproj/project.pbxproj
@@ -140,6 +140,9 @@
 		99C6D29E2C90379F009C0CF8 /* APIResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D29D2C90379F009C0CF8 /* APIResponseHandler.swift */; };
 		99C6D2A02C903EAF009C0CF8 /* ScheduleRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D29F2C903EAF009C0CF8 /* ScheduleRepository.swift */; };
 		99C6D2A32C904006009C0CF8 /* GetDDayScheduleUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C6D2A22C904006009C0CF8 /* GetDDayScheduleUseCase.swift */; };
+		99C921392D34B50E00FC2333 /* TokenReissueResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C921382D34B50E00FC2333 /* TokenReissueResponse.swift */; };
+		99C9213B2D34B56500FC2333 /* TokenReissueBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C9213A2D34B56500FC2333 /* TokenReissueBody.swift */; };
+		99C9213D2D34B72A00FC2333 /* TokenReissueUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C9213C2D34B72A00FC2333 /* TokenReissueUseCase.swift */; };
 		99C9B2292C0197CA008D7CBD /* Member.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C9B2282C0197CA008D7CBD /* Member.swift */; };
 		99C9B22C2C019C67008D7CBD /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C9B22B2C019C67008D7CBD /* LoginView.swift */; };
 		99C9B2322C01A45C008D7CBD /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C9B2312C01A45C008D7CBD /* Extensions.swift */; };
@@ -461,6 +464,9 @@
 		99C6D29D2C90379F009C0CF8 /* APIResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResponseHandler.swift; sourceTree = "<group>"; };
 		99C6D29F2C903EAF009C0CF8 /* ScheduleRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleRepository.swift; sourceTree = "<group>"; };
 		99C6D2A22C904006009C0CF8 /* GetDDayScheduleUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDDayScheduleUseCase.swift; sourceTree = "<group>"; };
+		99C921382D34B50E00FC2333 /* TokenReissueResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenReissueResponse.swift; sourceTree = "<group>"; };
+		99C9213A2D34B56500FC2333 /* TokenReissueBody.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenReissueBody.swift; sourceTree = "<group>"; };
+		99C9213C2D34B72A00FC2333 /* TokenReissueUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenReissueUseCase.swift; sourceTree = "<group>"; };
 		99C9B2282C0197CA008D7CBD /* Member.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Member.swift; sourceTree = "<group>"; };
 		99C9B22B2C019C67008D7CBD /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		99C9B2312C01A45C008D7CBD /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -790,6 +796,7 @@
 				992F57D32C5B28E900219C6B /* MemberSearchParameters.swift */,
 				99EDF5812CE862120008B19A /* MemberSnsBody.swift */,
 				99EDF5832CE864180008B19A /* DeleteMemberBody.swift */,
+				99C9213A2D34B56500FC2333 /* TokenReissueBody.swift */,
 			);
 			path = Member;
 			sourceTree = "<group>";
@@ -1071,6 +1078,7 @@
 				990F57A22C27F9FE00F6E1AD /* MemberDetailsUseCase.swift */,
 				992F57E42C5B623F00219C6B /* CheckEmailUseCase.swift */,
 				99EDF58B2CE877BD0008B19A /* DeleteMemberUseCase.swift */,
+				99C9213C2D34B72A00FC2333 /* TokenReissueUseCase.swift */,
 			);
 			path = Member;
 			sourceTree = "<group>";
@@ -1350,6 +1358,7 @@
 				99D780DF2C60670E005A3F30 /* MemberSearchResponse.swift */,
 				99D780E12C606726005A3F30 /* MemberDetailsResponse.swift */,
 				99D780E32C606735005A3F30 /* CheckEmailResponse.swift */,
+				99C921382D34B50E00FC2333 /* TokenReissueResponse.swift */,
 			);
 			path = Member;
 			sourceTree = "<group>";
@@ -2059,6 +2068,7 @@
 				D5BA30922CE745A700958BF5 /* PostFavoriteFriendBody.swift in Sources */,
 				D5B79A162C5B83CD004EDDF2 /* (null) in Sources */,
 				D534B0FE2D06F0FD004864E0 /* CoordinateService.swift in Sources */,
+				99C9213D2D34B72A00FC2333 /* TokenReissueUseCase.swift in Sources */,
 				997916922CFEE2BA001DED84 /* FeedDataManager.swift in Sources */,
 				9953583D2C00C555005BF799 /* AppDelegate.swift in Sources */,
 				99EFC76B2CD0B9560044DFC5 /* PostLocationUseCase.swift in Sources */,
@@ -2130,6 +2140,7 @@
 				D55C6C422CF5B8D7005132DC /* NavigationBarModifier.swift in Sources */,
 				99EDF5962CE8AD980008B19A /* GetFeedDetailsUseCase.swift in Sources */,
 				9910B8502C71E5B5005F7EEE /* ScheduleDropDownView.swift in Sources */,
+				99C9213B2D34B56500FC2333 /* TokenReissueBody.swift in Sources */,
 				99C68E522C64B96E00DEC1F1 /* EditFeedUseCase.swift in Sources */,
 				99C6D29E2C90379F009C0CF8 /* APIResponseHandler.swift in Sources */,
 				D54C040A2C6516CB009CC419 /* CreateScheduleBody.swift in Sources */,
@@ -2156,6 +2167,7 @@
 				995E3E5E2C508039006B4480 /* MyPageViewController.swift in Sources */,
 				D55C6C5C2CF70FF5005132DC /* GetListForReceiverUseCase.swift in Sources */,
 				99C6D29C2C903526009C0CF8 /* DDayScheduleResponse.swift in Sources */,
+				99C921392D34B50E00FC2333 /* TokenReissueResponse.swift in Sources */,
 				99CEAD4C2C5397B1006B3D41 /* DeviceConfig.swift in Sources */,
 				99949F5B2C58B85E00AE0177 /* Friend.swift in Sources */,
 				D55C6C472CF5D8DC005132DC /* PostFriendRequestBody.swift in Sources */,

--- a/Where_Are_You/Data/Models/Requests/Member/TokenReissueBody.swift
+++ b/Where_Are_You/Data/Models/Requests/Member/TokenReissueBody.swift
@@ -1,0 +1,12 @@
+//
+//  TokenReissueBody.swift
+//  Where_Are_You
+//
+//  Created by 오정석 on 13/1/2025.
+//
+
+import Foundation
+
+struct TokenReissueBody: ParameterConvertible {
+    let refreshToken: String
+}

--- a/Where_Are_You/Data/Models/Responses/Member/TokenReissueResponse.swift
+++ b/Where_Are_You/Data/Models/Responses/Member/TokenReissueResponse.swift
@@ -1,0 +1,14 @@
+//
+//  TokenReissueResponse.swift
+//  Where_Are_You
+//
+//  Created by 오정석 on 13/1/2025.
+//
+
+import Foundation
+
+struct TokenReissueResponse: Codable {
+    let accessToken: String
+    let refreshToken: String
+    let memberSeq: Int
+}

--- a/Where_Are_You/Data/Network/Member/MemberAPI.swift
+++ b/Where_Are_You/Data/Network/Member/MemberAPI.swift
@@ -12,6 +12,7 @@ enum MemberAPI {
     case putProfileImage(memberSeq: Int, images: UIImage)
     
     case postSignUp(request: SignUpBody)
+    case postTokenReissue(request: TokenReissueBody)
     case postMemberSns(request: MemberSnsBody)
     case postResetPassword(request: ResetPasswordBody)
     case postLogout(memberSeq: Int)
@@ -42,6 +43,8 @@ extension MemberAPI: TargetType {
             
         case .postSignUp:
             return "/member"
+        case .postTokenReissue:
+            return "/member/tokenReissue"
         case .postMemberSns:
             return "/member/sns"
         case .postResetPassword:
@@ -75,7 +78,7 @@ extension MemberAPI: TargetType {
         switch self {
         case .putUserName, .putProfileImage:
             return .put
-        case .postSignUp, .postMemberSns, .postResetPassword, .postLogout, .postLogin, .postMemberLink, .postEmailVerify, .postEmailVerifyPassword, .postEmailSend:
+        case .postSignUp, .postTokenReissue, .postMemberSns, .postResetPassword, .postLogout, .postLogin, .postMemberLink, .postEmailVerify, .postEmailVerifyPassword, .postEmailSend:
             return .post
         case .getMemberSearch, .getMemberDetails, .getCheckEmail:
             return .get
@@ -93,6 +96,8 @@ extension MemberAPI: TargetType {
             return .uploadMultipart(multipartData)
             
         case .postSignUp(let request):
+            return .requestParameters(parameters: request.toParameters() ?? [:], encoding: JSONEncoding.default)
+        case .postTokenReissue(let request):
             return .requestParameters(parameters: request.toParameters() ?? [:], encoding: JSONEncoding.default)
         case .postMemberSns(request: let request):
             return .requestParameters(parameters: request.toParameters() ?? [:], encoding: JSONEncoding.default)

--- a/Where_Are_You/Data/Network/Member/MemberService.swift
+++ b/Where_Are_You/Data/Network/Member/MemberService.swift
@@ -15,6 +15,7 @@ protocol MemberServiceProtocol {
     func putProfileImage(images: UIImage, completion: @escaping (Result<Void, Error>) -> Void)
     
     func postSignUp(request: SignUpBody, completion: @escaping (Result<Void, Error>) -> Void)
+    func postTokenReissue(request: TokenReissueBody, completion: @escaping (Result<GenericResponse<TokenReissueResponse>, Error>) -> Void)
     func postMemberSns(request: MemberSnsBody, completion: @escaping (Result<Void, Error>) -> Void)
     func postResetPassword(request: ResetPasswordBody, completion: @escaping (Result<Void, Error>) -> Void)
     func postLogout(completion: @escaping (Result<Void, Error>) -> Void)
@@ -63,6 +64,12 @@ class MemberService: MemberServiceProtocol {
     
     func postSignUp(request: SignUpBody, completion: @escaping (Result<Void, Error>) -> Void) {
         provider.request(.postSignUp(request: request)) { result in
+            APIResponseHandler.handleResponse(result, completion: completion)
+        }
+    }
+    
+    func postTokenReissue(request: TokenReissueBody, completion: @escaping (Result<GenericResponse<TokenReissueResponse>, any Error>) -> Void) {
+        provider.request(.postTokenReissue(request: request)) { result in
             APIResponseHandler.handleResponse(result, completion: completion)
         }
     }

--- a/Where_Are_You/Data/Repositories/MemberRepository.swift
+++ b/Where_Are_You/Data/Repositories/MemberRepository.swift
@@ -12,6 +12,7 @@ protocol MemberRepositoryProtocol {
     func putProfileImage(images: UIImage, completion: @escaping (Result<Void, Error>) -> Void)
     
     func postSignUp(request: SignUpBody, completion: @escaping (Result<Void, Error>) -> Void)
+    func postTokenReissue(request: TokenReissueBody, completion: @escaping (Result<GenericResponse<TokenReissueResponse>, Error>) -> Void)
     func postMemberSns(request: MemberSnsBody, completion: @escaping (Result<Void, Error>) -> Void)
     func postResetPassword(request: ResetPasswordBody, completion: @escaping (Result<Void, Error>) -> Void)
     func postLogout(completion: @escaping (Result<Void, Error>) -> Void)
@@ -45,7 +46,6 @@ class MemberRepository: MemberRepositoryProtocol {
         memberService.putProfileImage(images: images) { result in
             switch result {
             case .success:
-//                UserDefaultsManager.shared.saveProfileImage(images)
                 completion(.success(()))
             case .failure(let error):
                 completion(.failure(error))
@@ -57,6 +57,21 @@ class MemberRepository: MemberRepositoryProtocol {
     
     func postSignUp(request: SignUpBody, completion: @escaping (Result<Void, Error>) -> Void) {
         memberService.postSignUp(request: request, completion: completion)
+    }
+    
+    func postTokenReissue(request: TokenReissueBody, completion: @escaping (Result<GenericResponse<TokenReissueResponse>, any Error>) -> Void) {
+        memberService.postTokenReissue(request: request) { result in
+            switch result {
+            case .success(let response):
+                let data = response.data
+                UserDefaultsManager.shared.saveRefreshToken(data.refreshToken)
+                UserDefaultsManager.shared.saveMemberSeq(data.memberSeq)
+                UserDefaultsManager.shared.saveAccessToken(data.accessToken)
+                completion(.success(response))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
     
     func postMemberSns(request: MemberSnsBody, completion: @escaping (Result<Void, any Error>) -> Void) {

--- a/Where_Are_You/Data/Repositories/MemberRepository.swift
+++ b/Where_Are_You/Data/Repositories/MemberRepository.swift
@@ -87,7 +87,6 @@ class MemberRepository: MemberRepositoryProtocol {
             switch result {
             case .success:
                 UserDefaultsManager.shared.clearData()
-                UserDefaultsManager.shared.saveIsLoggedIn(false)
                 completion(.success(()))
             case .failure(let error):
                 completion(.failure(error))
@@ -154,6 +153,13 @@ class MemberRepository: MemberRepositoryProtocol {
     // MARK: - DELETE
     
     func deleteMember(request: DeleteMemberBody, completion: @escaping (Result<Void, any Error>) -> Void) {
-        memberService.deleteMember(request: request, completion: completion)
+        memberService.deleteMember(request: request) { result in
+            switch result {
+            case .success:
+                UserDefaultsManager.shared.clearData()
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
 }

--- a/Where_Are_You/Domain/UseCases/Member/TokenReissueUseCase.swift
+++ b/Where_Are_You/Domain/UseCases/Member/TokenReissueUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  TokenReissueUseCase.swift
+//  Where_Are_You
+//
+//  Created by 오정석 on 13/1/2025.
+//
+
+import Foundation
+
+protocol TokenReissueUseCase {
+    func execute(request: TokenReissueBody, completion: @escaping (Result<TokenReissueResponse, Error>) -> Void)
+}
+
+class TokenReissueUseCaseImpl: TokenReissueUseCase {
+    private let memberRepository: MemberRepositoryProtocol
+
+    init(memberRepository: MemberRepositoryProtocol) {
+        self.memberRepository = memberRepository
+    }
+    
+    func execute(request: TokenReissueBody, completion: @escaping (Result<TokenReissueResponse, any Error>) -> Void) {
+        memberRepository.postTokenReissue(request: request) { result in
+            switch result {
+            case .success(let response):
+                completion(.success(response.data))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/Where_Are_You/Utils/UserDefaultManager.swift
+++ b/Where_Are_You/Utils/UserDefaultManager.swift
@@ -90,7 +90,6 @@ class UserDefaultsManager {
     }
     
     // MARK: - ClearData
-    
     func clearData() {
         UserDefaults.standard.removeObject(forKey: accessTokenKey)
         UserDefaults.standard.removeObject(forKey: refreshTokenKey)
@@ -98,5 +97,6 @@ class UserDefaultsManager {
         UserDefaults.standard.removeObject(forKey: memberCode)
         UserDefaults.standard.removeObject(forKey: userName)
         UserDefaults.standard.removeObject(forKey: profileImage)
+        UserDefaults.standard.removeObject(forKey: isLoggedIn)
     }
 }


### PR DESCRIPTION
feat(#35): postTokenReissue API 구현
feat(#35): deleteMemberAPI 성공시 모든 UserDefaults데이터 삭제 추가