### PR TITLE
feat(#151): 로그인/에러 처리 부분 수정

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,6 +20,7 @@ target 'Where_Are_You' do
 	pod 'Firebase/Messaging'
 	pod 'IQKeyboardManager'
 	pod 'FloatingPanel'
+	pod 'Toast-Swift', '~> 5.1.1'
 
 	target 'Where_Are_You_Tests' do
 	  inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -125,6 +125,7 @@ PODS:
   - PromisesObjC (2.4.0)
   - SnapKit (5.7.1)
   - SwiftLint (0.57.1)
+  - Toast-Swift (5.1.1)
 
 DEPENDENCIES:
   - Alamofire (~> 5.6)
@@ -141,6 +142,7 @@ DEPENDENCIES:
   - Moya (~> 15.0)
   - SnapKit (~> 5.0)
   - SwiftLint
+  - Toast-Swift (~> 5.1.1)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
@@ -168,6 +170,7 @@ SPEC REPOS:
     - PromisesObjC
     - SnapKit
     - SwiftLint
+    - Toast-Swift
 
 SPEC CHECKSUMS:
   Alamofire: f36a35757af4587d8e4f4bfa223ad10be2422b8c
@@ -194,7 +197,8 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   SnapKit: d612e99e678a2d3b95bf60b0705ed0a35c03484a
   SwiftLint: 92196976e597b9afec5dbe374810103e6c1d9d7c
+  Toast-Swift: 7a03a532afe3a560d4044bc7c237e2864d295173
 
-PODFILE CHECKSUM: 435160d913fb25b326392f38bf19f1b41ec7ed89
+PODFILE CHECKSUM: 8bf75857347561d8a8a26967b242bbb2f550622d
 
 COCOAPODS: 1.16.2

--- a/Where_Are_You.xcodeproj/project.pbxproj
+++ b/Where_Are_You.xcodeproj/project.pbxproj
@@ -326,7 +326,7 @@
 		D5A91D5B2CBBADDB00DF0FA6 /* CustomAlertSwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5A91D5A2CBBADDB00DF0FA6 /* CustomAlertSwiftUI.swift */; };
 		D5AB2EE22D548E0D009E6741 /* MyLocation.gpx in Resources */ = {isa = PBXBuildFile; fileRef = D5AB2EE12D548E0D009E6741 /* MyLocation.gpx */; };
 		D5B3B5392CB3DE63004353F6 /* DailyScheduleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5B3B5382CB3DE63004353F6 /* DailyScheduleViewModel.swift */; };
-		D5B79A162C5B83CD004EDDF2 /* (null) in Sources */ = {isa = PBXBuildFile; };
+		D5B79A162C5B83CD004EDDF2 /* BuildFile in Sources */ = {isa = PBXBuildFile; };
 		D5BA308C2CE744C400958BF5 /* FriendAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BA308B2CE744C400958BF5 /* FriendAPI.swift */; };
 		D5BA308E2CE744CA00958BF5 /* FriendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BA308D2CE744CA00958BF5 /* FriendService.swift */; };
 		D5BA30902CE7453900958BF5 /* DeleteFriendBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5BA308F2CE7453900958BF5 /* DeleteFriendBody.swift */; };
@@ -2036,13 +2036,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Where_Are_You/Pods-Where_Are_You-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Where_Are_You/Pods-Where_Are_You-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2119,13 +2115,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Where_Are_You/Pods-Where_Are_You-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Where_Are_You/Pods-Where_Are_You-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -2221,7 +2213,7 @@
 				995175022C7EF95100E938DE /* LocationBookmarkViewModel.swift in Sources */,
 				D5CD68A42D351EA000B790E9 /* RefuseInvitedScheduleUseCase.swift in Sources */,
 				D5BA30922CE745A700958BF5 /* PostFavoriteFriendBody.swift in Sources */,
-				D5B79A162C5B83CD004EDDF2 /* (null) in Sources */,
+				D5B79A162C5B83CD004EDDF2 /* BuildFile in Sources */,
 				D5DCF8C42D69CA770045030C /* NotificationBadgeViewModel.swift in Sources */,
 				D534B0FE2D06F0FD004864E0 /* CoordinateService.swift in Sources */,
 				99C9213D2D34B72A00FC2333 /* TokenReissueUseCase.swift in Sources */,

--- a/Where_Are_You/Presentation/Login/Login/ViewControllers/AccountLoginController.swift
+++ b/Where_Are_You/Presentation/Login/Login/ViewControllers/AccountLoginController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Toast_Swift
 
 class AccountLoginController: UIViewController {
     // MARK: - Properties
@@ -57,20 +58,17 @@ class AccountLoginController: UIViewController {
         // 로그인 실패
         viewModel.onLoginFailure = { [weak self] message, isAvailable in
             // 로그인 실패
-            if message == " 비밀번호가 옳지 않습니다." {
+            if message == " 이메일 또는 비밀번호를 확인해주세요." {
                 self?.updateStatus(label: self?.accountLoginView.passwordErrorLabel,
                                    message: message,
                                    isAvailable: isAvailable,
                                    textField: self?.accountLoginView.passwordTextField)
                 self?.updateStatus(label: self?.accountLoginView.emailErrorLabel,
                                    message: "",
-                                   isAvailable: !isAvailable,
-                                   textField: self?.accountLoginView.emailTextField)
-            } else {
-                self?.updateStatus(label: self?.accountLoginView.emailErrorLabel,
-                                   message: message,
                                    isAvailable: isAvailable,
                                    textField: self?.accountLoginView.emailTextField)
+            } else {
+                self?.view.makeToast(message, duration: 2.0)
             }
         }
     }

--- a/Where_Are_You/Presentation/Login/Login/ViewModels/AccountLoginViewModel.swift
+++ b/Where_Are_You/Presentation/Login/Login/ViewModels/AccountLoginViewModel.swift
@@ -20,7 +20,8 @@ class AccountLoginViewModel {
     
     func login(email: String, password: String) {
         print("🔐FCM Token : \(UserDefaultsManager.shared.getFcmToken())")
-        accountLoginUseCase.execute(request: LoginBody(email: email, password: password, fcmToken: UserDefaultsManager.shared.getFcmToken(), loginType: "normal")) { result in
+        let fcmToken = UserDefaultsManager.shared.getFcmToken()
+        accountLoginUseCase.execute(request: LoginBody(email: email, password: password, fcmToken: fcmToken, loginType: "normal")) { result in
             switch result {
             case .success:
                 self.onLoginSuccess?()

--- a/Where_Are_You/Presentation/Login/SingUp/ViewControllers/TermsAgreementViewController.swift
+++ b/Where_Are_You/Presentation/Login/SingUp/ViewControllers/TermsAgreementViewController.swift
@@ -27,27 +27,42 @@ class TermsAgreementViewController: UIViewController {
     func buttonActions() {
         termsAgreementView.bottomButtonView.addTarget(self, action: #selector(agreeButtonTapped), for: .touchUpInside)
         termsAgreementView.agreeTermButton.addTarget(self, action: #selector(checkButtonTapped), for: .touchUpInside)
+        
         // 각 "보기" 버튼에 target 추가
         for (index, button) in termsAgreementView.termButtons.enumerated() {
             button.tag = index  // 각 버튼을 식별하기 위해 태그를 설정
             button.addTarget(self, action: #selector(termButtonTapped(_:)), for: .touchUpInside)
         }
-    }
-    
-    private func updateAgreeUI() {
-        if isAgreed {
-            // 동의 상태일 때: agreeTermButton과 bottomButtonView 모두 brandMain 색으로 변경하고, bottomButtonView 활성화
-            termsAgreementView.agreeTermButton.tintColor = .brandMain
-            termsAgreementView.bottomButtonView.updateBackgroundColor(.brandMain)
-            termsAgreementView.bottomButtonView.isEnabled = true
-        } else {
-            // 미동의 상태일 때: 기본 색상으로 변경 및 bottomButtonView 비활성화
-            termsAgreementView.agreeTermButton.tintColor = .blackAC
-            termsAgreementView.bottomButtonView.updateBackgroundColor(.blackAC)
-            termsAgreementView.bottomButtonView.isEnabled = false
+        
+        for button in termsAgreementView.checkButtons {
+            button.addTarget(self, action: #selector(individualCheckToggled(_:)), for: .touchUpInside)
         }
     }
     
+    private func updateAgreeUI() {
+        let buttons = termsAgreementView.checkButtons
+        let required = termsAgreementView.requiredIndices
+        let all = termsAgreementView.allIndices
+        
+        // 필수 약관만 모두 체크되었는지 여부
+        let allRequiredAgreed = required.allSatisfy { buttons[$0].isSelected }
+        
+        // 전체 약관(필수 + 선택) 모두 체크되었는지 여부
+        let allTotallyAgreed = all.allSatisfy { buttons[$0].isSelected }
+        
+        // 전체 동의 버튼은 전체 체크되었을 때만 선택 상태로 유지
+        termsAgreementView.agreeTermButton.isSelected = allTotallyAgreed
+        isAgreed = allTotallyAgreed
+        
+        termsAgreementView.agreeTermButton.tintColor = allTotallyAgreed ? .brandMain : .blackAC
+        termsAgreementView.bottomButtonView.updateBackgroundColor(allRequiredAgreed ? .brandMain : .blackAC)
+        termsAgreementView.bottomButtonView.isEnabled = allRequiredAgreed
+    }
+    
+    private func updateButtonTintColor(_ button: UIButton) {
+        button.tintColor = button.isSelected ? .brandMain : .blackAC
+    }
+
     // MARK: - Selectors
     
     @objc func backButtonTapped() {
@@ -56,6 +71,33 @@ class TermsAgreementViewController: UIViewController {
     
     @objc func checkButtonTapped() {
         isAgreed.toggle()
+        termsAgreementView.agreeTermButton.isSelected = isAgreed
+        for button in termsAgreementView.checkButtons {
+            button.isSelected = isAgreed
+        }
+        
+        let allButtons = [termsAgreementView.agreeTermButton] + termsAgreementView.checkButtons
+        allButtons.forEach {
+            $0.isSelected = isAgreed
+            updateButtonTintColor($0)
+        }
+        updateAgreeUI()
+    }
+    
+    @objc func individualCheckToggled(_ sender: UIButton) {
+        sender.isSelected.toggle()
+        
+//        // 필수 항목이 모두 체크되었는지 확인
+//        let allRequiredAgreed = termsAgreementView.requiredIndices.allSatisfy {
+//            termsAgreementView.checkButtons[$0].isSelected
+//        }
+//        
+//        // 전체 동의 상태 갱신
+//        isAgreed = allRequiredAgreed
+//        termsAgreementView.agreeTermButton.isSelected = isAgreed
+
+        updateButtonTintColor(sender)
+
         updateAgreeUI()
     }
     

--- a/Where_Are_You/Presentation/Login/SingUp/Views/TermsAgreementView.swift
+++ b/Where_Are_You/Presentation/Login/SingUp/Views/TermsAgreementView.swift
@@ -12,6 +12,9 @@ class TermsAgreementView: UIView {
     
     // MARK: - Properties
     var termButtons: [UIButton] = []
+    var checkButtons: [UIButton] = []
+    let requiredIndices: Set<Int> = [0, 1] // 필수 항목 인덱스
+    let allIndices: Set<Int> = [0, 1, 2]
 
     private let progressBar: UIView = {
         let view = UIView()
@@ -47,8 +50,10 @@ class TermsAgreementView: UIView {
     
     let agreeTermButton: UIButton = {
         let button = UIButton()
-        let image = UIImage(named: "icon-checkBox")?.withRenderingMode(.alwaysTemplate)
+        let image = UIImage(systemName: "circle")
+        let selectedImage = UIImage(systemName: "checkmark.circle.fill")
         button.setImage(image, for: .normal)
+        button.setImage(selectedImage, for: .selected)
         button.tintColor = .blackAC
         return button
     }()
@@ -109,6 +114,10 @@ class TermsAgreementView: UIView {
             make.leading.trailing.equalToSuperview()
         }
         
+        agreeTermButton.snp.makeConstraints { make in
+            make.width.height.equalTo(LayoutAdapter.shared.scale(value: 24))
+        }
+        
         termTitleStackView.snp.makeConstraints { make in
             make.top.equalToSuperview().inset(LayoutAdapter.shared.scale(value: 30))
             make.leading.equalToSuperview().inset(LayoutAdapter.shared.scale(value: 27))
@@ -122,7 +131,19 @@ class TermsAgreementView: UIView {
         }
     }
     
-    private func createTermRow(title: String) -> UIStackView {
+    private func createTermRow(title: String, index: Int) -> UIStackView {
+        let checkButton = UIButton()
+        let image = UIImage(systemName: "circle")
+        let selectedImage = UIImage(systemName: "checkmark.circle.fill")
+        checkButton.setImage(image, for: .normal)
+        checkButton.setImage(selectedImage, for: .selected)
+        checkButton.tintColor = .blackAC
+        checkButton.tag = index
+        checkButtons.append(checkButton)
+        checkButton.snp.makeConstraints { make in
+            make.width.height.equalTo(LayoutAdapter.shared.scale(value: 20))
+        }
+        
         // 약관 제목을 표시하는 라벨
         let titleLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP3(text: title, textColor: .black22))
         
@@ -132,14 +153,18 @@ class TermsAgreementView: UIView {
             make.height.equalTo(22)
         }
         termButtons.append(viewButton)
-
-        // 가로 스택 뷰에 라벨과 버튼 추가
-        let rowStack = UIStackView(arrangedSubviews: [titleLabel, viewButton])
+        
+        let contentStack = UIStackView(arrangedSubviews: [checkButton, titleLabel])
+        contentStack.spacing = 6
+        
+        let rowStack = UIStackView(arrangedSubviews: [contentStack, viewButton])
         rowStack.axis = .horizontal
         rowStack.spacing = 0
+        rowStack.distribution = .equalSpacing
+        return rowStack
         
-        // 라벨과 버튼 사이의 공간을 유연하게 분배하려면 라벨의 content hugging priority를 낮게 설정 가능
-        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        //라벨과 버튼 사이의 공간을 유연하게 분배하려면 라벨의 content hugging priority를 낮게 설정 가능
+        contentStack.setContentHuggingPriority(.defaultLow, for: .horizontal)
         viewButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         
         return rowStack
@@ -149,13 +174,13 @@ class TermsAgreementView: UIView {
         // 약관 항목들을 배열로 정의
         let terms = [
             "서비스 이용약관 (필수)",
-            "개인정보 처리방침 (필수)"
-//            "위치기반 서비스 이용약관 (필수)" 추후 추가 예정
+            "개인정보 처리방침 (필수)",
+            "위치기반 서비스 이용약관 (선택)"
         ]
         
         // 각 항목에 대해 rowStack을 생성하여 배열에 담습니다.
-        let termRows = terms.map { createTermRow(title: $0) }
-        
+        let termRows = terms.enumerated().map { createTermRow(title: $1, index: $0) }
+
         // 세로 스택 뷰 생성
         let termsStackView = UIStackView(arrangedSubviews: termRows)
         termsStackView.axis = .vertical

--- a/Where_Are_You/Utils/APIError.swift
+++ b/Where_Are_You/Utils/APIError.swift
@@ -29,9 +29,9 @@ enum APIError: Error {
     var localizedDescription: String {
         switch self {
         case .emailError:
-            return " 이메일이 올바르지 않습니다."
+            return " 이메일 또는 비밀번호를 확인해주세요."
         case .passwordError:
-            return " 비밀번호가 옳지 않습니다."
+            return " 이메일 또는 비밀번호를 확인해주세요."
         case .serverError:
             return " 서버에 오류가 발생했습니다."
         case .unknownError(let message):


### PR DESCRIPTION
feat(#151): 로그인/에러 처리 부분 수정

1. 이메일, 비밀번호 오류는 이제 하나의 문구로 통일해서 비밀번호 텍스트 필드 하단에 에러문구 띄움.
2. 이메일, 비밀번호 제외 오류들은 토스트 메시지로 뜨게 설정
3. 회원가입/약관동의 부분에서 체크 박스를 추가하여 전체동의, 각각의 약관 동의를 체크 할수 있도록 설정