### PR TITLE
refactor(#151): 계정찾기, 비밀번호 재설정

### DIFF
--- a/Where_Are_You/Domain/UseCases/Member/CheckEmailUseCase.swift
+++ b/Where_Are_You/Domain/UseCases/Member/CheckEmailUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol CheckEmailUseCase {
-    func execute(email: String, completion: @escaping (Result<CheckEmailResponse, ValidationError>) -> Void)
+    func execute(email: String, completion: @escaping (Result<CheckEmailResponse, Error>) -> Void)
 }
 
 class CheckEmailUseCaseImpl: CheckEmailUseCase {
@@ -18,13 +18,13 @@ class CheckEmailUseCaseImpl: CheckEmailUseCase {
         self.memberRepository = memberRepository
     }
 
-    func execute(email: String, completion: @escaping (Result<CheckEmailResponse, ValidationError>) -> Void) {
+    func execute(email: String, completion: @escaping (Result<CheckEmailResponse, Error>) -> Void) {
         memberRepository.getCheckEmail(email: email) { result in
             switch result {
             case .success(let response):
                 completion(.success(response.data))
-            case .failure:
-                completion(.failure(.duplicateEmail))
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }

--- a/Where_Are_You/Presentation/Login/CommonDescription.swift
+++ b/Where_Are_You/Presentation/Login/CommonDescription.swift
@@ -11,7 +11,7 @@ import Foundation
 let invalidUserNameMessage = "이름은 1~4자의 한글을 입력해주세요"
 
 // 비밀번호 형식 확인, 일치 확인
-let invalidPasswordMessage = "영문 소문자, 숫자, 특수문자만 사용하여 시작하는 6~20자의 영문 대소문자, 숫자를 \n포함해 입력해주세요."
+let invalidPasswordMessage = "영문 소문자, 숫자, 특수문자만 사용하여 시작하는 6~20자의 영문 대소문자, 숫자를 포함해 입력해주세요."
 let checkPasswordFailureMessage = "비밀번호가 일치하지 않습니다."
 
 // 이메일 전송, 인증

--- a/Where_Are_You/Presentation/Login/FindAccount/ViewControllers/PasswordResetViewController.swift
+++ b/Where_Are_You/Presentation/Login/FindAccount/ViewControllers/PasswordResetViewController.swift
@@ -86,6 +86,9 @@ class PasswordResetViewController: UIViewController {
         passwordResetView.resetPasswordTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         passwordResetView.checkPasswordTextField.addTarget(self, action: #selector(textFieldDidChange(_:)), for: .editingChanged)
         passwordResetView.bottomButtonView.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        
+        passwordResetView.hidePasswordButton.addTarget(self, action: #selector(hidePasswordButtonTapped(_:)), for: .touchUpInside)
+        passwordResetView.hideCheckPasswordButton.addTarget(self, action: #selector(hidePasswordButtonTapped(_:)), for: .touchUpInside)
     }
     
     // MARK: - Selectors
@@ -106,6 +109,19 @@ class PasswordResetViewController: UIViewController {
     
     @objc func backButtonTapped() {
         dismiss(animated: true)
+    }
+    
+    @objc func hidePasswordButtonTapped(_ button: UIButton) {
+        switch button {
+        case passwordResetView.hidePasswordButton:
+            passwordResetView.hidePasswordButton.isSelected.toggle()
+            passwordResetView.resetPasswordTextField.isSecureTextEntry.toggle()
+        case passwordResetView.hideCheckPasswordButton:
+            passwordResetView.hideCheckPasswordButton.isSelected.toggle()
+            passwordResetView.checkPasswordTextField.isSecureTextEntry.toggle()
+        default:
+            break
+        }
     }
     
     @objc func confirmButtonTapped() {

--- a/Where_Are_You/Presentation/Login/FindAccount/ViewModels/AcoountSearchViewModel.swift
+++ b/Where_Are_You/Presentation/Login/FindAccount/ViewModels/AcoountSearchViewModel.swift
@@ -57,7 +57,7 @@ class AcoountSearchViewModel {
                 self.requestEmailCode(email: data.email)
                 self.emailType = data.type
             case .failure:
-                self.onRequestCodeFailure?("\(ValidationError.invalidEmailFormat)")
+                self.onRequestCodeFailure?("이메일 형식에 알맞지 않습니다.")
             }
         }
     }
@@ -85,7 +85,7 @@ class AcoountSearchViewModel {
                     self.onVerifyCodeSuccess?(" 인증코드가 확인되었습니다.")
                     self.timerHelper.stopTimer()
                 case .failure:
-                    self.onVerifyCodeFailure?(" 인증코드가 알맞지 않습니다.")
+                    self.onVerifyCodeFailure?(" 인증코드가 일치하지 않습니다.")
                 }
             }
         }

--- a/Where_Are_You/Presentation/Login/FindAccount/ViewModels/ResetPasswordViewModel.swift
+++ b/Where_Are_You/Presentation/Login/FindAccount/ViewModels/ResetPasswordViewModel.swift
@@ -39,7 +39,7 @@ class ResetPasswordViewModel {
         if ValidationHelper.isValidPassword(pw) {
             onPasswordValidation?("", true)
         } else {
-            onPasswordValidation?(" 영문 대문자, 소문자로 시작하는 6~20자의 영문 대문자, 소문자, 숫자를 \n 포함해 입력해주세요.", false)
+            onPasswordValidation?(" 영문 대소문자로 시작하는 6~20자의 영문 대소문자, 숫자를 \n 포함해 입력해주세요.", false)
         }
     }
     

--- a/Where_Are_You/Presentation/Login/FindAccount/Views/AccountCheckView.swift
+++ b/Where_Are_You/Presentation/Login/FindAccount/Views/AccountCheckView.swift
@@ -13,7 +13,7 @@ class AccountCheckView: UIView {
     
     private let titleLabel = StandardLabel(UIFont: UIFont.CustomFont.titleH1(text: "회원님의 가입정보를 \n확인해주세요", textColor: .black22))
     
-    private let emailLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP4(text: "회원님의 가입정보와 일치하는 이메일 주소는", textColor: .black22))
+    private let emailLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP4(text: "회원님의 가입정보와 일치하는 이메일은", textColor: .black22))
     
     let accountImage: UIImageView = {
         let imageView = UIImageView()
@@ -38,7 +38,7 @@ class AccountCheckView: UIView {
         return view
     }()
     
-    private let descriptionLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP4(text: "로그인 또는 비밀번호 찾기 버튼을 눌러주세요.", textColor: .black66))
+    private let descriptionLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP4(text: "로그인 또는 비밀번호 재설정 버튼을 눌러주세요.", textColor: .black66))
     
     let loginButton = TitleButton(title: UIFont.CustomFont.button18(text: "로그인하기", textColor: .white), backgroundColor: .brandMain, borderColor: nil)
     

--- a/Where_Are_You/Presentation/Login/FindAccount/Views/PasswordResetView.swift
+++ b/Where_Are_You/Presentation/Login/FindAccount/Views/PasswordResetView.swift
@@ -11,11 +11,19 @@ import SnapKit
 class PasswordResetView: UIView {
     // MARK: - Properties
     
-    private let titleLabel = StandardLabel(UIFont: UIFont.CustomFont.titleH1(text: "회원님의 비밀번호를 재설정해주세요.", textColor: .black22))
+    private let titleLabel = StandardLabel(UIFont: UIFont.CustomFont.titleH1(text: "회원님의 비밀번호를 \n재설정 해주세요.", textColor: .black22))
     
     private let passwordLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: "비밀번호", textColor: .black22))
     
     let resetPasswordTextField = CustomTextField(placeholder: "비밀번호")
+    
+    let hidePasswordButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "eye.slash"), for: .normal)
+        button.setImage(UIImage(systemName: "eye"), for: .selected)
+        button.tintColor = .blackAC
+        return button
+    }()
     
     let resetPasswordDescription = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: " 영문 대소문자로 시작하는 6~20자의 영문 대소문자, 숫자를 \n 포함해 입력해주세요.", textColor: .brandMain))
     
@@ -27,6 +35,14 @@ class PasswordResetView: UIView {
     }()
     
     let checkPasswordTextField = CustomTextField(placeholder: "비밀번호 확인")
+    
+    let hideCheckPasswordButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "eye.slash"), for: .normal)
+        button.setImage(UIImage(systemName: "eye"), for: .selected)
+        button.tintColor = .blackAC
+        return button
+    }()
     
     let checkPasswordDescription = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: "비밀번호가 일치하지 않습니다.", textColor: .error))
     
@@ -66,6 +82,8 @@ class PasswordResetView: UIView {
         addSubview(titleLabel)
         addSubview(stack)
         addSubview(bottomButtonView)
+        addSubview(hidePasswordButton)
+        addSubview(hideCheckPasswordButton)
     }
     
     private func setupConstraints() {
@@ -78,6 +96,18 @@ class PasswordResetView: UIView {
             make.leading.equalTo(titleLabel.snp.leading)
             make.centerX.equalToSuperview()
             make.top.equalTo(titleLabel.snp.bottom).offset(LayoutAdapter.shared.scale(value: 50))
+        }
+        
+        hidePasswordButton.snp.makeConstraints { make in
+            make.centerY.equalTo(resetPasswordTextField)
+            make.width.height.equalTo(LayoutAdapter.shared.scale(value: 20))
+            make.trailing.equalTo(resetPasswordTextField.snp.trailing).inset(LayoutAdapter.shared.scale(value: 12))
+        }
+        
+        hideCheckPasswordButton.snp.makeConstraints { make in
+            make.centerY.equalTo(checkPasswordTextField)
+            make.width.height.equalTo(LayoutAdapter.shared.scale(value: 20))
+            make.trailing.equalTo(checkPasswordTextField.snp.trailing).inset(LayoutAdapter.shared.scale(value: 12))
         }
         
         bottomButtonView.snp.makeConstraints { make in

--- a/Where_Are_You/Presentation/Login/Login/ViewControllers/AccountLoginController.swift
+++ b/Where_Are_You/Presentation/Login/Login/ViewControllers/AccountLoginController.swift
@@ -75,7 +75,10 @@ class AccountLoginController: UIViewController {
     
     // MARK: - Selectors
     @objc private func backButtonTapped() {
-        dismiss(animated: true)
+        let loginVC = LoginViewController()
+        let nav = UINavigationController(rootViewController: loginVC)
+        nav.modalPresentationStyle = .fullScreen
+        self.present(nav, animated: true, completion: nil)
     }
     
     // viewmodel에 로그인하기 버튼 활성화 비활성화 로직 추가하기

--- a/Where_Are_You/Presentation/Login/SingUp/ViewControllers/SignUpFormViewController.swift
+++ b/Where_Are_You/Presentation/Login/SingUp/ViewControllers/SignUpFormViewController.swift
@@ -11,7 +11,6 @@ class SignUpFormViewController: UIViewController {
     // MARK: - Properties
     let signUpView = SignUpFormView()
     private var viewModel: SignUpViewModel!
-    var type: [String] = []
     
     // MARK: - Lifecycle
     
@@ -97,7 +96,7 @@ class SignUpFormViewController: UIViewController {
         }
         
         viewModel.onCheckEmailDuplicate = { [weak self] type in
-            self?.type = type
+            // 이 부분은 이메일 로직 수정되면서 삭제/수정 될 예정
         }
         
         viewModel.onEmailVerifyCodeMessage = { [weak self] message, isAvailable in
@@ -160,8 +159,10 @@ class SignUpFormViewController: UIViewController {
     @objc func hidePasswordButtonTapped(_ button: UIButton) {
         switch button {
         case signUpView.hidePasswordButton:
+            signUpView.hidePasswordButton.isSelected.toggle()
             signUpView.passwordTextField.isSecureTextEntry.toggle()
         case signUpView.hideCheckPasswordButton:
+            signUpView.hideCheckPasswordButton.isSelected.toggle()
             signUpView.checkPasswordTextField.isSecureTextEntry.toggle()
         default:
             break
@@ -169,14 +170,7 @@ class SignUpFormViewController: UIViewController {
     }
     
     @objc func startButtonTapped() {
-        if type.isEmpty {
-            viewModel.signUp()
-        } else {
-            let email = viewModel.email
-            guard let password = viewModel.signUpBody.password, let userName = viewModel.signUpBody.userName else { return }
-            let controller = SocialLinkViewController(email: email, password: password, userName: userName, loginType: "normal", linkLoginType: type)
-            navigationController?.pushViewController(controller, animated: true)
-        }
+        viewModel.signUp()
     }
     
     // MARK: - Helpers

--- a/Where_Are_You/Presentation/Login/SingUp/Views/FinishRegisterview.swift
+++ b/Where_Are_You/Presentation/Login/SingUp/Views/FinishRegisterview.swift
@@ -48,15 +48,15 @@ class FinishRegisterview: UIView {
         }
         
         titleLabel.snp.makeConstraints { make in
-            make.top.equalTo(progressBar).offset(30)
-            make.leading.equalToSuperview().offset(15)
-            make.width.equalToSuperview().multipliedBy(0.477)
-            make.height.equalTo(titleLabel.snp.width).multipliedBy(0.402)
+            make.top.equalTo(progressBar).offset(54)
+            make.leading.equalToSuperview().offset(24)
+//            make.width.equalToSuperview().multipliedBy(0.477)
+//            make.height.equalTo(titleLabel.snp.width).multipliedBy(0.402)
         }
         
         descriptionLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(titleLabel.snp.bottom).offset(26)
+            make.top.equalTo(titleLabel.snp.bottom).offset(38)
             make.leading.equalTo(titleLabel)
         }
         


### PR DESCRIPTION
refactor(#151): 계정찾기, 비밀번호 재설정

1. 비밀번호 재설정 -> 비밀번호 숨기기 온/오프 버튼 추가
2. 계정찾기 -> UI 문구 수정
3. 회원가입 -> 이메일 중복 체크하여 type값 받아오는 부분 제거(sns 연동 부분을 마이페이지로 이동하여 더이상 type값을 받아서 다음 화면에 보여줄 필요가 없어짐)