### PR TITLE
refactor(#144): 홈화면 피드 선택시 넘어가는 디테일 피드 부분 수정

### DIFF
--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/ViewControllers/DetailFeedslViewController.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/ViewControllers/DetailFeedslViewController.swift
@@ -98,6 +98,12 @@ class FeedDetailViewController: UIViewController {
         // 참가자 정보 로드 (뷰 모델 혹은 네트워크 호출)
         let participants = viewModel.getParticipants()
         feedDetailView.configureParticipants(participants: participants)
+        
+        // representFeed의 작성자가 몇 번째인지 찾음
+        let memberSeq = representFeed.memberSeq
+        if let selectedIndex = participants.firstIndex(where: { $0.memberSeq == memberSeq }) {
+            feedDetailView.selectParticipant(at: selectedIndex)
+        }
     }
     
     private func showOptions(for feed: Feed, at frame: CGRect, isAuthor: Bool) {

--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/DetailFeed/FeedDetailView.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/DetailFeed/FeedDetailView.swift
@@ -84,6 +84,11 @@
             noFeedView.isHidden = true
             scrollView.isHidden = false
         }
+        
+        func selectParticipant(at index: Int) {
+            guard let button = participantsBoxView.participantStackView.arrangedSubviews[index] as? GradientButton else { return }
+            participantsBoxView.performSelectAction(for: button)
+        }
     }
 
     extension FeedDetailView: FeedParticipantDelegate {

--- a/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/DetailFeed/FeedParticipantView.swift
+++ b/Where_Are_You/Presentation/Main/FriendFeed/Feeds/Views/DetailFeed/FeedParticipantView.swift
@@ -112,6 +112,11 @@ class FeedParticipantView: UIView {
         selectedButton = button
     }
     
+    func performSelectAction(for button: GradientButton) {
+        updateSelectedButton(button)
+        delegate?.didSelectParticipant(at: button.tag)
+    }
+    
     @objc private func didTapParticipantButton(_ sender: GradientButton) {
         updateSelectedButton(sender)
 

--- a/Where_Are_You/Presentation/Main/Mypage/ViewControllers/MyDetailManageViewcontroller.swift
+++ b/Where_Are_You/Presentation/Main/Mypage/ViewControllers/MyDetailManageViewcontroller.swift
@@ -73,7 +73,7 @@ class MyDetailManageViewcontroller: UIViewController {
    
     // 초기 설정
     private func configureInitialState() {
-        mydetailManageView.emailTextfield.attributedText = UIFont.CustomFont.bodyP3(text: email, textColor: .black66)
+        mydetailManageView.emailTextfield.setupTextField(placeholder: email)
         mydetailManageView.emailTextfield.isUserInteractionEnabled = false
         mydetailManageView.emailTextfield.backgroundColor = .blackF0
         mydetailManageView.userNameTextField.isUserInteractionEnabled = isEditingMode
@@ -86,7 +86,7 @@ class MyDetailManageViewcontroller: UIViewController {
         viewModel.onChangeNameSuccess = { [weak self] userName in
             DispatchQueue.main.async {
                 self?.userName = userName
-                self?.mydetailManageView.userNameTextField.attributedText = UIFont.CustomFont.bodyP3(text: userName, textColor: .black66)
+                self?.mydetailManageView.userNameTextField.setupTextField(placeholder: userName)
                 self?.mydetailManageView.userNameTextField.isEnabled = false
                 self?.mydetailManageView.updateDetailButton.updateTitle("수정되었습니다")
                 self?.mydetailManageView.updateDetailButton.updateBackgroundColor(.blackAC)

--- a/Where_Are_You/Presentation/Main/Mypage/Views/MyDetailManageView.swift
+++ b/Where_Are_You/Presentation/Main/Mypage/Views/MyDetailManageView.swift
@@ -11,7 +11,7 @@ class MyDetailManageView: UIView {
     // MARK: - Properties
     let modifyButton = CustomOptionButtonView(title: "수정하기")
     
-    private let userNameLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: " 이름", textColor: .black22))
+    private let userNameLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: "이름", textColor: .black22), isPaddingLabel: true)
     
     var userNameTextField = CustomTextField(placeholder: "")
     
@@ -24,7 +24,7 @@ class MyDetailManageView: UIView {
         return stackView
     }()
     
-    private let emailLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: " 이메일 주소", textColor: .black22))
+    private let emailLabel = StandardLabel(UIFont: UIFont.CustomFont.bodyP5(text: "이메일 주소", textColor: .black22), isPaddingLabel: true)
         
     var emailTextfield = CustomTextField(placeholder: "")
     

--- a/Where_Are_You/Utils/Customs/CustomTextField.swift
+++ b/Where_Are_You/Utils/Customs/CustomTextField.swift
@@ -44,6 +44,12 @@ class CustomTextField: UITextField {
         }
     }
     
+    func setupTextField(inputAttributedText: NSAttributedString?) {
+        if let displayText = inputAttributedText {
+            self.attributedText = displayText
+        }
+    }
+    
     private func setupBorder() {
         if hasBorder {
             layer.borderColor = UIColor.blackD4.cgColor


### PR DESCRIPTION
refactor(#144): 홈화면 피드 선택시 넘어가는 디테일 피드 부분 수정

1. 홈화면 피드 선택해서 디테일 피드로 넘어갈시 누른 피드 데이터는 뜨지만 상단의 participantBoxView의 버튼은 제대로 값을 따라가지 않아. 해당 데이터 값에 따라 버튼이 변경되도록 코드 추가
