### PR TITLE
Fix network status property usage

### DIFF
--- a/Config/DeviceConfig.swift
+++ b/Config/DeviceConfig.swift
@@ -11,14 +11,15 @@ import SystemConfiguration
 class DeviceManager {
     static let shared: DeviceManager = DeviceManager()
     
-    var networkStatue: Bool {
+    /// Current network reachability status
+    var networkStatus: Bool {
         return checkDeviceNetworkStatus()
     }
     
     private init() {}
     
     private func checkDeviceNetworkStatus() -> Bool {
-            print("Check to Device Natwork Status....")
+            print("Check Device Network Status....")
             var zeroAddress = sockaddr_in(sin_len: 0, sin_family: 0, sin_port: 0, sin_addr: in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
             zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
             zeroAddress.sin_family = sa_family_t(AF_INET)

--- a/Where_Are_You/Resources/LaunchScreen/SplashViewController.swift
+++ b/Where_Are_You/Resources/LaunchScreen/SplashViewController.swift
@@ -46,7 +46,7 @@ class SplashViewController: UIViewController {
     }
     
     func checkDeviceNetworkStatus() {
-        if !(DeviceManager.shared.networkStatue) {
+        if !(DeviceManager.shared.networkStatus) {
             DispatchQueue.main.async {
                 let networkAlert = NetworkAlert(action: {
                     self.checkDeviceNetworkStatus()


### PR DESCRIPTION
## Summary
- correct network status property name
- reference new property in splash screen

## Testing
- `xcodebuild -list -project Where_Are_You.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd8278c6c832ab05d242eab1baae9